### PR TITLE
Add AFRICLOUD (AS209179) - Resolves #107

### DIFF
--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -616,6 +616,26 @@ const data: ProviderData[] = [
       "startPrice": 294,
       "link": "https://pawhost.de/"
     }
+    ,
+    {
+      "provider": {
+        "logo": "/img/africloud.png",
+        "logo_include_text": true,
+        "name": "AFRICLOUD",
+        "asn": 209179
+      },
+      "locations": ["Lisbon, PT", "Johannesburg, ZA", "Lagos, NG"],
+      "services": ["VPS"],
+      "routes": "Full + default",
+      "bgpFeatures": ['BGP Communities', 'BGP Community Passthrough', 'Downstream Support'],
+      "bgpFee": "None",
+      "bgpFilters": ["Automatic IRR", "RPKI", "LOA Required"],
+      "notes": "Peering at NAPAfrica Johannesburg, IXPN Lagos, DE-CIX Lisbon and DE-CIX Madrid. IPv6 included on every server.",
+      "pricing": "Starting at $10 USD",
+      "startPrice": 1000,
+      "link": "https://africloud.com/order"
+    }
+
   ];
 
 export default data;


### PR DESCRIPTION
Adds AFRICLOUD as submitted in issue #107, which has been open since December 2025. The issue body has been updated today with our third region and two fields that were previously left blank.

Three regions: Lisbon PT, Johannesburg ZA and Lagos NG. AS209179 peers at NAPAfrica Johannesburg, IXPN Lagos, DE-CIX Lisbon and DE-CIX Madrid, all verifiable via PeeringDB and bgp.tools. RPKI origin validation with invalid-reject on all sessions, LOA required, IPv6 on every server, full table plus default, downstream support via AS-SET. No BGP fee.

The logo file is not included in this commit. Happy to add public/img/africloud.png in a follow-up, or you are welcome to pull it from the issue attachment if you would rather place it yourselves.